### PR TITLE
Perpare textile-mode for inclusion in NonGNU ELPA

### DIFF
--- a/textile-mode.el
+++ b/textile-mode.el
@@ -3,7 +3,9 @@
 ;; Copyright (C) 2006 Free Software Foundation, Inc.
 
 ;; Author: Julien Barnier <julien@nozav.org>
-;; $Id: textile-mode.el 6 2006-03-30 22:37:08Z juba $
+;; URL: https://github.com/juba/textile-mode
+;; Keywords: wp, languages
+;; Version: 1.0.0
 
 ;; This file is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by
@@ -22,10 +24,10 @@
 
 ;;; Commentary:
 
-;;
+;; An emacs major mode for Textile markup language 
+;; (https://textile-lang.com/) editing.
 
-
-;; Known bugs or limitations:
+;;; Known bugs or limitations:
 
 ;; - if several {style}, [lang] or (class) attributes are given for
 ;;   the same block, only the first one of each type will be
@@ -33,13 +35,8 @@
 ;;
 ;; - some complex imbrications of inline markup and attributes are
 ;;   not well-rendered (for example, *strong *{something}notstrong*)
-;;
-
-
 
 ;;; Code:
-
-
 
 (defvar textile-mode-map
   (let ((map (make-sparse-keymap)))


### PR DESCRIPTION
Hi,

I would like to suggest adding textile-mode to NonGNU ELPA. Compared to MELPA, ELPA repositories have slightly stricter formatting rules, such as the requirement to maintain a version attribute in the package header.

This patch should fix everything required for textile mode to be added to the new package repository, I would take care of the rest.