### PR TITLE
Fix inline code highlight

### DIFF
--- a/textile-mode.el
+++ b/textile-mode.el
@@ -103,6 +103,15 @@ non-matching parentheses"
    markup
    "\\)\\W"))
 
+(defun textile-inline-code-matcher (markup)
+  "Return the matcher regexp for an inline code"
+  (concat
+   "\\W\\("
+   markup
+   ".+?"
+   markup
+   "\\)\\W"))
+
 (defun textile-list-bullet-matcher (bullet)
   "Return the matcher regexp for a list bullet"
   (concat
@@ -185,7 +194,7 @@ non-matching parentheses"
        ;; citation
        `(,(textile-inline-markup-matcher "\\?\\?") 1 'textile-citation-face prepend t)
        ;; code
-       `(,(textile-inline-markup-matcher "@") 1 'textile-inline-code-face t t)
+       `(,(textile-inline-code-matcher "@") 1 'textile-inline-code-face t t)
        ;; deletion
        `(,(textile-inline-markup-matcher "-") 1 'textile-deleted-face prepend t)
        ;; insertion

--- a/textile-mode.el
+++ b/textile-mode.el
@@ -24,7 +24,7 @@
 
 ;;; Commentary:
 
-;; An emacs major mode for Textile markup language 
+;; An emacs major mode for Textile markup language
 ;; (https://textile-lang.com/) editing.
 
 ;;; Known bugs or limitations:
@@ -185,7 +185,7 @@ non-matching parentheses"
        ;; citation
        `(,(textile-inline-markup-matcher "\\?\\?") 1 'textile-citation-face prepend t)
        ;; code
-       `(,(textile-inline-markup-matcher "@") 1 'textile-inline-code-face prepend t)
+       `(,(textile-inline-markup-matcher "@") 1 'textile-inline-code-face t t)
        ;; deletion
        `(,(textile-inline-markup-matcher "-") 1 'textile-deleted-face prepend t)
        ;; insertion


### PR DESCRIPTION
This fixes a few problems with "inline-code" highlight not working that I encountered while using the mode to highlight text in Redmine system. See individual commit messages for examples that are getting fixed.

There are still more issues, I'll look at them later.