### PR TITLE
Fix "no lexical-binding" warning

### DIFF
--- a/textile-mode.el
+++ b/textile-mode.el
@@ -1,4 +1,4 @@
-;;; textile-mode.el --- Textile markup editing major mode
+;;; textile-mode.el --- Textile markup editing major mode -*- lexical-binding: t -*-
 
 ;; Copyright (C) 2006 Free Software Foundation, Inc.
 


### PR DESCRIPTION
Upstream Emacs has enabled warnings for files with no lexical binding, so compiling this file or loading with native-comp enabled results in:

     ~/.emacs.d/elpa/textile-mode-20230112.1030/textile-mode.el:1:1: Warning: file has no ‘lexical-binding’ directive on its first line

Fix that.